### PR TITLE
Move paginate tests to main_test.go

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -59,7 +59,8 @@ func CreateGithubMilestoneMap(githubAPI []githubAPI) map[string]utils.Milestone 
 	return milestones
 }
 
-func paginate(URL string, token string) ([][]byte, error) {
+// Paginate checks the linkHeader returned by the API and if a next page is present, appends the data to a [][]byte
+func Paginate(URL string, token string) ([][]byte, error) {
 	apiData := make([][]byte, 1)
 	client := &http.Client{}
 	paginate := true
@@ -171,7 +172,7 @@ func getMilestones(baseURL string, token string, project string, state string) (
 	q.Set("state", state)
 	u.RawQuery = q.Encode()
 	newURL = u.String()
-	apiData, err := paginate(newURL, token)
+	apiData, err := Paginate(newURL, token)
 	if err != nil {
 		return nil, err
 	}

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -41,26 +41,6 @@ func TestGithubCreateAndDisplayNewMilestones(t *testing.T) {
 	}
 }
 
-func TestPaginate(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-	pages := MockPaginate("https://example.com")
-	apiData, err := paginate("https://example.com", "token")
-	if err != nil {
-		t.Error(err)
-	}
-	if len(apiData) != pages {
-		t.Errorf("Expected %d, got %d", pages, len(apiData))
-	}
-}
-
-func TestPaginateFailWhenURLisWrong(t *testing.T) {
-	_, err := paginate("https://example.c_m", "token")
-	if err == nil {
-		t.Errorf("Expected to get an error when url is wrong")
-	}
-}
-
 func TestGetActiveMilestones(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()

--- a/github/testing.go
+++ b/github/testing.go
@@ -99,34 +99,3 @@ func MockGithubAPIPatchRequest(URL string, state string, id string) {
 		},
 	)
 }
-
-// MockPaginate creates a mock responder to return a byte slice
-func MockPaginate(url string) int {
-	linkHeader := []string{
-		"<http://example.com/page=1>; rel=\"next\", <http://example.com/page=3>; rel=\"last\"",
-		"<http://example.com/page=3>; rel=\"next\", <http://example.com/page=3>; rel=\"last\"",
-		"<http://example.com/page=2>; rel=\"first\", <http://example.com/page=3>; rel=\"last\"",
-	}
-	links := []string{
-		"http://example.com/page=1",
-		"http://example.com/page=3",
-		"http://example.com/page=2",
-	}
-	for i, link := range linkHeader {
-		httpmock.RegisterResponder("GET", links[i],
-			func(req *http.Request) (*http.Response, error) {
-				resp := httpmock.NewStringResponse(200, "testing")
-				resp.Header.Set("Link", link)
-				return resp, nil
-			},
-		)
-	}
-	httpmock.RegisterResponder("GET", url,
-		func(req *http.Request) (*http.Response, error) {
-			resp := httpmock.NewStringResponse(200, "testing")
-			resp.Header.Set("Link", linkHeader[0])
-			return resp, nil
-		},
-	)
-	return len(linkHeader)
-}

--- a/main_test.go
+++ b/main_test.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/okkur/gomiler/github"
 	httpmock "gopkg.in/jarcoal/httpmock.v1"
 )
 
@@ -89,7 +90,7 @@ func TestPaginate(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 	pages := mockPaginate("https://example.com")
-	apiData, err := paginate("https://example.com", "token")
+	apiData, err := github.Paginate("https://example.com", "token")
 	if err != nil {
 		t.Error(err)
 	}
@@ -99,7 +100,7 @@ func TestPaginate(t *testing.T) {
 }
 
 func TestPaginateFailWhenURLisWrong(t *testing.T) {
-	_, err := paginate("https://example.c_m", "token")
+	_, err := github.Paginate("https://example.c_m", "token")
 	if err == nil {
 		t.Errorf("Expected to get an error when url is wrong")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, paginate tests are located in the GitHub directory. Since the paginate functions are essentially the same, it is only necessary to test one of them. Because of this, the paginate tests can be moved to main_test.go.

**Which issue this PR fixes**:
fixes #53 